### PR TITLE
#167727443 Setup travisci with readme badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: node_js
+
+node_js:
+  - "v10.15.3"
+
+cache:
+  directories:
+    - node_modules
+
+install:
+  - npm install
+
+services:
+  - postgresql
+
+before_script:
+  - psql -c "CREATE DATABASE testing_db;" -U postgres
+
+script:
+  - npm test


### PR DESCRIPTION
What does this PR do?
Integrate TravisCI with badge attached to readme

Description of Task to be completed?
-activate TravisCI for northstar-backend repository
-add a .travis.yml file at the project's root folder
-integrate TravisCI badge in readme file

Any background context you want to provide?
TravisCI is a hosted continous integration service used to build and test software projects hosted at Github

What are the relevant pivotal tracker stories?
#167727443

Screenshots (if appropriate)
![Screenshot (463)](https://user-images.githubusercontent.com/33726993/63304206-89b13400-c2e2-11e9-977e-8b7896621c34.png)
