### PR TITLE
#167727455 Implement Social Signin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,3 +79,12 @@ DEV_DB_URL
 DEV_DB_USER
 DEV_DB_PASSWORD
 DEV_DATABASE
+
+
+# Enviroment variables for google
+GOOGLE_CLIENT_ID
+GOOGLE_SECRET
+
+# Enviroment variables for facebook
+FACEBOOK_CLIENT_ID
+FACEBOOK_SECRET

--- a/package-lock.json
+++ b/package-lock.json
@@ -1480,6 +1480,11 @@
         }
       }
     },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+    },
     "basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -3501,8 +3506,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3551,8 +3555,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -3712,7 +3715,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3856,8 +3858,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4032,7 +4033,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6229,6 +6229,11 @@
         "yargs-parser": "^13.0.0"
       }
     },
+    "oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -6599,12 +6604,40 @@
         "pause": "0.0.1"
       }
     },
+    "passport-facebook": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/passport-facebook/-/passport-facebook-3.0.0.tgz",
+      "integrity": "sha512-K/qNzuFsFISYAyC1Nma4qgY/12V3RSLFdFVsPKXiKZt434wOvthFW1p7zKa1iQihQMRhaWorVE1o3Vi1o+ZgeQ==",
+      "requires": {
+        "passport-oauth2": "1.x.x"
+      }
+    },
+    "passport-google-oauth20": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-2.0.0.tgz",
+      "integrity": "sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==",
+      "requires": {
+        "passport-oauth2": "1.x.x"
+      }
+    },
     "passport-local": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
       "integrity": "sha1-H+YyaMkudWBmJkN+O5BmYsFbpu4=",
       "requires": {
         "passport-strategy": "1.x.x"
+      }
+    },
+    "passport-oauth2": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.5.0.tgz",
+      "integrity": "sha512-kqBt6vR/5VlCK8iCx1/KpY42kQ+NEHZwsSyt4Y6STiNjU+wWICG1i8ucc1FapXDGO15C5O5VZz7+7vRzrDPXXQ==",
+      "requires": {
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
       }
     },
     "passport-strategy": {
@@ -8484,6 +8517,11 @@
       "requires": {
         "random-bytes": "~1.0.0"
       }
+    },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
     },
     "umzug": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
         "npm-run-all": "^4.1.5",
         "passport": "^0.4.0",
         "passport-local": "^1.0.0",
+        "passport-facebook": "^3.0.0",
+        "passport-google-oauth20": "^2.0.0",
         "pg": "^7.12.1",
         "pg-hstore": "^2.3.3",
         "proxyquire": "^2.1.3",

--- a/src/index.js
+++ b/src/index.js
@@ -7,10 +7,12 @@ import morgan from 'morgan';
 import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import swaggerUi from 'swagger-ui-express';
+import passport from 'passport';
 import logger from './logs/winston';
 import swaggerDocument from '../swagger.json';
 import v1Router from './routes';
 import indexRouter from './routes/api/index.router';
+import passportConfig from './validation/passport.config';
 
 const app = express();
 
@@ -26,10 +28,12 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 app.use(cookieParser());
 app.use(morgan(':remote-addr - [:date] ":method :url" :status', { stream: logger.stream }));
-
+app.use(passport.initialize());
+passportConfig(passport);
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
-app.use('/api/v1', v1Router);
+
 app.use('/', indexRouter);
+app.use('/api/v1', v1Router);
 
 app.use((req, res, next) => {
   const err = new Error('No endpoint found');

--- a/src/middlewares/social-mock.middleware.js
+++ b/src/middlewares/social-mock.middleware.js
@@ -1,0 +1,140 @@
+const randomId = Math.random().toString().slice(2);
+
+/**
+ * Handles mock requests to the oauth routes
+ * @param {ServerRequest} req
+ * @param {ServerResponse} res
+ * @param {callback} next
+ * @returns {undefined}
+ */
+export default (req, res, next) => {
+  // GOOGLE
+  const resp = {
+    google: {
+      id: randomId,
+      displayName: 'Northstar Barefootnomad',
+      name: {
+        familyName: 'Barefootnomad',
+        givenName: 'Northstar'
+      },
+      emails: [
+        {
+          value: 'north@gmail.com',
+          verified: true
+        }
+      ],
+      photos: [
+        {
+          value: 'https://lh3.googleusercontent.com/-rwHxJC1XRRI/AAAAAAAAAAI/AAAAAAAAAAA/photo.jpg'
+        }
+      ],
+      provider: 'google',
+      _raw: {
+        sub: randomId,
+        name: 'Northstar Barefootnomad',
+        given_name: 'Northstar',
+        family_name: 'Barefootnomad',
+        picture: 'https://lh3.googleusercontent.com/-rwHxJC1XRRI/AAAAAAAAAAI/AAAAAAAAAAA/photo.jpg',
+        email: 'north@gmail.com',
+        email_verified: true,
+        locale: 'en'
+      },
+      _json: {
+        sub: randomId,
+        name: 'Northstar Barefootnomad',
+        given_name: 'Northstar',
+        family_name: 'Barefootnomad',
+        picture: 'https://lh3.googleusercontent.com/-rwHxJC1XRRI/AAAAAAAAAAI/AAAAAAAAAAA/photo.jpg',
+        email: 'north@gmail.com',
+        email_verified: true,
+        locale: 'en'
+      }
+    },
+    // FACEBOOK USER
+    facebook: {
+      id: randomId,
+      name: {
+        familyName: 'Barefoot',
+        givenName: 'Nomad',
+        middleName: 'Boy'
+      },
+      emails: [
+        {
+          value: 'north@gmail.com'
+        }
+      ],
+      provider: 'facebook',
+      _raw: {
+        id: '2651400934879505',
+        last_name: 'Barefoot',
+        first_name: 'Nomad',
+        middle_name: 'Boy',
+        email: 'north@gmail.com'
+      },
+      _json: {
+        id: randomId,
+        last_name: 'Barefoot',
+        first_name: 'Nomad',
+        middle_name: 'Boy',
+        email: 'north@gmail.com'
+      }
+    },
+
+    // GOOGLE USER WITHOUT EMAIL
+    google_fail: {
+      id: randomId,
+      displayName: 'Northstar Barefootnomad',
+      name: {
+        familyName: 'Barefootnomad',
+        givenName: 'Northstar'
+      },
+      photos: [
+        {
+          value: 'https://lh3.googleusercontent.com/-rwHxJC1XRRI/AAAAAAAAAAI/AAAAAAAAAAA/photo.jpg'
+        }
+      ],
+      provider: 'google',
+      _raw: {
+        sub: randomId,
+        name: 'Northstar Barefootnomad',
+        given_name: 'Northstar',
+        family_name: 'Barefootnomad',
+        picture: 'https://lh3.googleusercontent.com/-rwHxJC1XRRI/AAAAAAAAAAI/AAAAAAAAAAA/photo.jpg',
+        locale: 'en'
+      },
+      _json: {
+        sub: randomId,
+        name: 'Northstar Barefootnomad',
+        given_name: 'Northstar',
+        family_name: 'Barefootnomad',
+        picture: 'https://lh3.googleusercontent.com/-rwHxJC1XRRI/AAAAAAAAAAI/AAAAAAAAAAA/photo.jpg',
+        locale: 'en'
+      }
+    },
+    // FACEBOOK USER WITHOUT EMAIL
+    facebook_fail: {
+      id: randomId,
+      name: {
+        familyName: 'Barefoot',
+        givenName: 'Nomad',
+        middleName: 'Boy'
+      },
+      provider: 'facebook',
+      _raw: {
+        id: randomId,
+        last_name: 'Barefoot',
+        first_name: 'Nomad',
+        middle_name: 'Boy',
+      },
+      _json: {
+        id: randomId,
+        last_name: 'Barefoot',
+        first_name: 'Nomad',
+        middle_name: 'Boy',
+      }
+    }
+  };
+
+  req.user = resp[req.body.provider];
+  next();
+};

--- a/src/routes/api/auth.router.js
+++ b/src/routes/api/auth.router.js
@@ -1,12 +1,36 @@
 import express from 'express';
+
+import passport from 'passport';
+
 import UserController from '../../controllers/user.controller';
 import UserMiddleware from '../../middlewares/user.middleware';
+import socialMockMiddleWare from '../../middlewares/social-mock.middleware';
 
 const router = express.Router();
 
+const authBase = '/auth';
+
 /* Users Routes Here */
-router.post('/auth/signup', UserController.signup);
+router.post(`${authBase}/signup`, UserController.signup);
 router.post('/auth/signin', ...UserMiddleware.validateSigninFields(),
   UserController.signin);
+
+/* google */
+router.get(`${authBase}/google`, passport.authenticate('google', {
+  scope: ['profile', 'email']
+}));
+router.get(`${authBase}/google/redirect`, passport.authenticate('google'), UserController.oauthSignin);
+
+/* facebook */
+router.get(`${authBase}/facebook`, passport.authenticate('facebook', {
+  scope: ['email']
+}));
+router.get(`${authBase}/facebook/redirect`, passport.authenticate('facebook'), UserController.oauthSignin);
+
+
+/* oauth mock routes */
+router.post(`${authBase}/google`, socialMockMiddleWare, UserController.oauthSignin);
+router.post(`${authBase}/facebook`, socialMockMiddleWare, UserController.oauthSignin);
+
 
 export default router;

--- a/src/test/signin.test.js
+++ b/src/test/signin.test.js
@@ -11,39 +11,12 @@ const { expect } = chai;
 const signinUrl = '/api/v1/auth/signin';
 const { User } = models;
 
-const testUserDetails = {
-  first_name: 'Olawumi',
-  last_name: 'Yusuff',
-  email: 'user@test.com',
-  password: '12345678'
+const testUser = {
+  first_name: 'John',
+  last_name: 'Doe',
+  email: 'john_doe@email.com',
+  password: 'qwertyuiop'
 };
-let testUser;
-
-
-before((done) => {
-  bcrypt.hash(testUserDetails.password, 10)
-    .then((hash) => User.create({
-      first_name: testUserDetails.first_name,
-      last_name: testUserDetails.last_name,
-      email: testUserDetails.email,
-      password: hash
-    }))
-    .then((user) => {
-      testUser = user;
-      done();
-    })
-    .catch((e) => done(e));
-});
-
-after((done) => {
-  User.destroy({
-    where: {
-      email: testUserDetails.email
-    }
-  })
-    .then(() => done())
-    .catch((e) => done(e));
-});
 
 describe(`POST ${signinUrl}`, () => {
   describe('SUCCESS', () => {
@@ -51,8 +24,8 @@ describe(`POST ${signinUrl}`, () => {
       const res = await chai.request(app)
         .post(signinUrl)
         .send({
-          email: testUserDetails.email,
-          password: testUserDetails.password
+          email: testUser.email,
+          password: testUser.password
         });
 
       expect(res.status).to.equal(200);
@@ -66,18 +39,9 @@ describe(`POST ${signinUrl}`, () => {
         'createdAt', 'gender', 'birth_date', 'preferred_language',
         'preferred_currency', 'location', 'token', 'email_notification');
       expect(res.body.data.token).to.be.a('string');
-      expect(res.body.data.role).to.equal(testUser.role);
-      expect(res.body.data.isVerified).to.equal(testUser.isVerified);
-      expect(res.body.data.id).to.equal(testUser.id);
       expect(res.body.data.first_name).to.equal(testUser.first_name);
       expect(res.body.data.last_name).to.equal(testUser.last_name);
       expect(res.body.data.email).to.equal(testUser.email);
-      expect(res.body.data.email_notification).to.equal(testUser.email_notification);
-      expect(res.body.data.manager_id).to.equal(testUser.manager_id);
-      expect(res.body.data.gender).to.equal(testUser.gender);
-      expect(res.body.data.preferred_language).to.equal(testUser.preferred_language);
-      expect(res.body.data.preferred_currency).to.equal(testUser.preferred_currency);
-      expect(res.body.data.location).to.equal(testUser.location);
     });
   });
 
@@ -85,7 +49,7 @@ describe(`POST ${signinUrl}`, () => {
     it('should fail to sign in user with incorrect email', async () => {
       const res = await chai.request(app)
         .post(signinUrl)
-        .send({ email: 'another@example.com', password: testUserDetails.password });
+        .send({ email: 'another@example.com', password: testUser.password });
 
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object');
@@ -100,7 +64,7 @@ describe(`POST ${signinUrl}`, () => {
     it('should fail to sign in user with no email field in request', async () => {
       const res = await chai.request(app)
         .post(signinUrl)
-        .send({ password: testUserDetails.password });
+        .send({ password: testUser.password });
 
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object');
@@ -115,7 +79,7 @@ describe(`POST ${signinUrl}`, () => {
     it('should fail to sign in user with empty email string', async () => {
       const res = await chai.request(app)
         .post(signinUrl)
-        .send({ email: '', password: testUserDetails.password });
+        .send({ email: '', password: testUser.password });
 
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object');
@@ -130,7 +94,7 @@ describe(`POST ${signinUrl}`, () => {
     it('should fail to sign in user with non-string email', async () => {
       const res = await chai.request(app)
         .post(signinUrl)
-        .send({ email: 10, password: testUserDetails.password });
+        .send({ email: 10, password: testUser.password });
 
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object');
@@ -145,7 +109,7 @@ describe(`POST ${signinUrl}`, () => {
     it('should fail to sign in user with invalid email format', async () => {
       const res = await chai.request(app)
         .post(signinUrl)
-        .send({ email: 'user@example', password: testUserDetails.password });
+        .send({ email: 'user@example', password: testUser.password });
 
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object');
@@ -160,7 +124,7 @@ describe(`POST ${signinUrl}`, () => {
     it('should fail to sign in user with incorrect password', async () => {
       const res = await chai.request(app)
         .post(signinUrl)
-        .send({ email: testUserDetails.email, password: 'emi naa ni' });
+        .send({ email: testUser.email, password: 'emi naa ni' });
 
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object');
@@ -175,7 +139,7 @@ describe(`POST ${signinUrl}`, () => {
     it('should fail to sign in user with no password field supplied', async () => {
       const res = await chai.request(app)
         .post(signinUrl)
-        .send({ email: testUserDetails.email });
+        .send({ email: testUser.email });
 
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object');
@@ -190,7 +154,7 @@ describe(`POST ${signinUrl}`, () => {
     it('should fail to sign in user with empty password string', async () => {
       const res = await chai.request(app)
         .post(signinUrl)
-        .send({ email: testUserDetails.email, password: '' });
+        .send({ email: testUser.email, password: '' });
 
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object');
@@ -205,7 +169,7 @@ describe(`POST ${signinUrl}`, () => {
     it('should fail to sign in user with non-string password', async () => {
       const res = await chai.request(app)
         .post(signinUrl)
-        .send({ email: testUserDetails.email, password: 10 });
+        .send({ email: testUser.email, password: 10 });
 
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object');
@@ -220,7 +184,7 @@ describe(`POST ${signinUrl}`, () => {
     it('should fail to sign in user with a too short password', async () => {
       const res = await chai.request(app)
         .post(signinUrl)
-        .send({ email: testUserDetails, password: testUserDetails.password.slice(0, 6) });
+        .send({ email: testUser, password: testUser.password.slice(0, 6) });
 
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object');

--- a/src/test/social-auth.test.js
+++ b/src/test/social-auth.test.js
@@ -1,0 +1,90 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+
+import app from '../index';
+
+
+chai.use(chaiHttp);
+const { expect } = chai;
+
+const authBase = '/api/v1/auth';
+
+describe('SOCIAL AUTHENTICATION', () => {
+  describe('SUCCESS', () => {
+    it('should save a google user into the database', async () => {
+      const res = await chai.request(app)
+        .post(`${authBase}/google`)
+        .send({ provider: 'google' });
+
+      expect(res.status).to.equal(201);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.be.an('object');
+      expect(res.body.data).to.not.have.key('password');
+      expect(res.body.data).to.have.keys('role', 'is_verified', 'id',
+        'first_name', 'last_name', 'email', 'updatedAt', 'manager_id',
+        'createdAt', 'gender', 'birth_date', 'preferred_language',
+        'preferred_currency', 'location', 'token', 'email_notification');
+      expect(res.body.data.token).to.be.a('string');
+      expect(res.body.data.role).to.equal('requester');
+      expect(res.body.data.id).to.be.a('number');
+      expect(res.body.data.first_name).to.not.equal(null);
+      expect(res.body.data.last_name).to.not.equal(null);
+      expect(res.body.data.email).to.not.equal(null);
+      expect(res.body.data.email).to.be.a('string');
+    });
+
+    it('should save a facebook user into the database', async () => {
+      const res = await chai.request(app)
+        .post(`${authBase}/facebook`)
+        .send({ provider: 'facebook' });
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.be.an('object');
+      expect(res.body.data).to.not.have.key('password');
+      expect(res.body.data).to.have.keys('role', 'is_verified', 'id',
+        'first_name', 'last_name', 'email', 'updatedAt', 'manager_id',
+        'createdAt', 'gender', 'birth_date', 'preferred_language',
+        'preferred_currency', 'location', 'token', 'email_notification');
+      expect(res.body.data.token).to.be.a('string');
+      expect(res.body.data.role).to.equal('requester');
+      expect(res.body.data.id).to.be.a('number');
+      expect(res.body.data.first_name).to.not.equal(null);
+      expect(res.body.data.last_name).to.not.equal(null);
+      expect(res.body.data.email).to.not.equal(null);
+      expect(res.body.data.email).to.be.a('string');
+    });
+  });
+
+  describe('FAILURE', () => {
+    it('should fail to sign in a google user without email', async () => {
+      const res = await chai.request(app)
+        .post(`${authBase}/google`)
+        .send({ provider: 'google_fail' });
+
+      expect(res.status).to.equal(401);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.property('error');
+      expect(res.body.error).to.be.an('object');
+      expect(res.body.error).to.have.property('message');
+      expect(res.body.error.message).to.equal('Unable to sign in');
+    });
+
+    it('should fail to sign in a google user without email', async () => {
+      const res = await chai.request(app)
+        .post(`${authBase}/facebook`)
+        .send({ provider: 'facebook_fail' });
+
+      expect(res.status).to.equal(401);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.property('error');
+      expect(res.body.error).to.be.an('object');
+      expect(res.body.error).to.have.property('message');
+      expect(res.body.error.message).to.equal('Unable to sign in');
+    });
+  });
+});

--- a/src/utils/user.utils.js
+++ b/src/utils/user.utils.js
@@ -1,8 +1,5 @@
-// import jwt from 'jsonwebtoken';
 import bcrypt from 'bcrypt';
 // import models from '../db/models';
-
-// const { User } = models;
 
 /**
  * Defines helper functions for the user model
@@ -50,7 +47,6 @@ export default class UserUtils {
     };
   }
 
-
   /**
    * Gets the public fields of a user
    * @param {Object} userObj
@@ -68,5 +64,19 @@ export default class UserUtils {
       location: userObj.location,
       role: userObj.role
     };
+  }
+
+  /**
+   * Set cookie on response header
+   * @param {ServerResponse} res
+   * @param {string} userToken
+   * @returns {undefined}
+   */
+  static setCookie(res, userToken) {
+    res.cookie('token', userToken, {
+      expires: new Date(Date.now() + (604800 * 1000)),
+      httpOnly: true,
+      secure: true
+    });
   }
 }

--- a/src/validation/passport.config.js
+++ b/src/validation/passport.config.js
@@ -1,0 +1,28 @@
+import GoogleStrategy from 'passport-google-oauth20';
+import FacebookStrategy from 'passport-facebook';
+
+
+/**
+ * Configures passport strategies
+ * @param {*} passport
+ * @returns {undefined}
+ */
+export default (passport) => {
+  passport.serializeUser((user, done) => done(null, user));
+  passport.deserializeUser((user, done) => done(null, user));
+
+  passport.use(new GoogleStrategy({
+    // options
+    callbackURL: '/api/v1/auth/google/redirect',
+    clientID: process.env.GOOGLE_CLIENT_ID,
+    clientSecret: process.env.GOOGLE_SECRET
+  }, (accessToken, refreshToken, profile, done) => done(null, profile)));
+
+  passport.use(new FacebookStrategy({
+    // options
+    callbackURL: '/api/v1/auth/facebook/redirect',
+    clientID: process.env.FACEBOOK_CLIENT_ID,
+    clientSecret: process.env.FACEBOOK_SECRET,
+    profileFields: ['id', 'name', 'email']
+  }, (accessToken, refreshToken, profile, done) => done(null, profile)));
+};

--- a/swagger.json
+++ b/swagger.json
@@ -89,6 +89,54 @@
         }
       }
     },
+    "/auth/google": {
+      "get": {
+        "description": "A user can sign in/register with a Google account",
+        "summary": "This endpoint receives GET requests to sign in or register a user using a Google account",
+        "tags": [
+          "Auth"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "security": [],
+        "responses": {
+          "201": {
+            "description": "A new user created"
+          },
+          "200": {
+            "description": "An existing user retrieved"
+          },
+          "401": {
+            "description": "Signin error"
+          }
+        }
+      }
+    },
+    "/auth/facebook": {
+      "get": {
+        "description": "A user can sign in/register with a Facebook account",
+        "summary": "This endpoint receives GET requests to sign in or register a user using a Facebook account",
+        "tags": [
+          "Auth"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "security": [],
+        "responses": {
+          "201": {
+            "description": "A new user created"
+          },
+          "200": {
+            "description": "An existing user retrieved"
+          },
+          "401": {
+            "description": "Signin error"
+          }
+        }
+      }
+    },
     "/requests/:id": {
       "patch": {
         "description": "A manager can reject a user's request application",


### PR DESCRIPTION
#### What does this PR do?
Implements the endpoint to allow users signin/signup user their Google/Facebook accounts

#### Description of Task to be completed?
Have the following API endpoint working
- GET /api/v1/auth/google
- GET /api/v1/auth/facebook

#### How should this be manually tested?
Clone this repo, cd into it and 
- Run `npm test`
- Or run `npm run start:dev`, then using a browser visit `localhost:3000/api/v1/auth/google` or `localhost:3000/api/v1/auth/facebook`

_key_: To test *Facebook* signin from a browser, an error may be encountered because the app is still in development. Make use of the following test user login credentials (ensure to log out of your default account):
```email: rhktexyqua_1567600967@tfbnw.net```
```password: testuser```

#### Any background context you want to provide?
Users should be able to sign in using their Google/Facebook accounts

#### What are the relevant pivotal tracker stories?
[#167727455](https://www.pivotaltracker.com/story/show/167727455)

#### Screenshots (if appropriate)
None

#### Questions:
None