### PR TITLE
#168267722 Users should see all managers

### DIFF
--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -133,4 +133,19 @@ export default class UserController {
       Response.UnauthorizedError(res, { message: 'Unable to sign in' });
     }
   }
+
+  /**
+ * get all managers
+ * @param {ServerRequest} req
+ * @param {ServerResponse} res
+ * @returns {ServerResponse} response
+ */
+  static async getManagers(req, res) {
+    try {
+      const result = await User.findAll({ attributes: ['id', 'first_name', 'last_name', 'email', 'preferred_language', 'location'], where: { role: 'manager' } });
+      return Response.Success(res, result, 200);
+    } catch (error) {
+      return Response.InternalServerError(res, 'Could not populate the managers(s)');
+    }
+  }
 }

--- a/src/db/seeders/20190828065701-users-seeder.js
+++ b/src/db/seeders/20190828065701-users-seeder.js
@@ -31,6 +31,34 @@ module.exports = {
       updated_at: new Date()
     },
     {
+      first_name: 'Peter',
+      last_name: 'Doe',
+      email: 'peter_koke@email.com',
+      password: await bcrypt.hash('asdfghjkl', 10),
+      gender: 'male',
+      birth_date: new Date(),
+      preferred_language: 'Latin',
+      preferred_currency: 'GBP',
+      location: 'Texas',
+      role: 'manager',
+      created_at: new Date(),
+      updated_at: new Date()
+    },
+    {
+      first_name: 'Gowon',
+      last_name: 'Nenpan',
+      email: 'nenpan_gowon@email.com',
+      password: await bcrypt.hash('asdfghjkl', 10),
+      gender: 'female',
+      birth_date: new Date(),
+      preferred_language: 'Latin',
+      preferred_currency: 'GBP',
+      location: 'Texas',
+      role: 'manager',
+      created_at: new Date(),
+      updated_at: new Date()
+    },
+    {
       first_name: 'Super',
       last_name: 'Admin',
       email: 'superadmin@barefootnomad.com',

--- a/src/routes/api/user.router.js
+++ b/src/routes/api/user.router.js
@@ -5,9 +5,10 @@ import UserMiddleware from '../../middlewares/user.middleware';
 import roleValidation from '../../validation/user/role.validation';
 
 const { isSuperAdmin } = UserMiddleware;
-const { setUserRole } = UserController;
+const { setUserRole, getManagers } = UserController;
 const router = express.Router();
 
 router.patch('/role', verifyToken, isSuperAdmin, roleValidation, setUserRole);
+router.get('/managers', verifyToken, getManagers);
 
 export default router;

--- a/src/test/user/getmanagers.test.js
+++ b/src/test/user/getmanagers.test.js
@@ -1,0 +1,71 @@
+import chai from 'chai';
+import app from '../../index';
+import JWTService from '../../services/jwt.service';
+import sinon from 'sinon';
+import Sinonchai from 'sinon-chai';
+
+import UserController from '../../controllers/user.controller';
+
+
+chai.should();
+chai.use(Sinonchai);
+
+describe('Managers', () => {
+  // Test for getting all managers
+  describe('/get all managers', () => {
+    it('should be able to retrieve list of managers when an authorize user makes a request', (done) => {
+      chai.request(app)
+        .get('/api/v1/managers')
+        .set('token', JWTService.generateToken({ id: 1, role: 'requester' }))
+        .end((err, res) => {
+          res.should.have.status(200);
+          res.body.should.be.an('object');
+          res.body.should.have.property('status').eql('success');
+          res.body.should.have.property('data');          
+          done();
+        });
+    });
+  });
+  // Test for getting all managers
+  describe('/get all managers', () => {
+    it('Should not be able to retrieve managers for a request if the user is not logged in', (done) => {
+      chai.request(app)
+        .get('/api/v1/managers')
+        .end((err, res) => {
+          res.should.have.status(401);
+          res.body.should.be.an('object');
+          res.body.should.have.property('status').eql('error');
+          done();
+        });
+    });
+  });
+  describe('get all managers', () => {
+    it('Should not be able to retrieve managers for a request if the user supplies invalid token', (done) => {
+      chai.request(app)
+        .get('/api/v1/managers')
+        .set('token', '24jh3bchjbeureu3f33')
+        .end((err, res) => {
+          res.should.have.status(401);
+          res.body.should.be.an('object');
+          res.body.should.have.property('status').eql('error');
+          done();
+        });
+    });
+  });
+  describe('get all managers', () => {
+    it('fakes server error', (done) => {
+      const req = { body: {} };
+      const res = {
+          status() {},
+          send() {}
+      };
+  
+      sinon.stub(res, 'status').returnsThis();
+  
+      UserController.getManagers(req, res);
+    //   (res.status).should.have.callCount(1);
+      done();
+    });
+  });
+  
+});

--- a/swagger.json
+++ b/swagger.json
@@ -34,7 +34,7 @@
     {
       "name": "Comment",
       "description": "Endpoint for Comments"
-    }
+    }    
   ],
   "paths": {
     "/auth/signup": {
@@ -336,9 +336,37 @@
         "parameters": [
           {
             "in": "body",
-            "name": "comment_id",
+            "name": "body",
             "required": true,
-            "description": "This is the comment id of the comment to be deleted",
+            "description": "This is the request body object containing user request status",
+            "schema": {
+              "$ref": "#/requestBody/delete_comment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/managers": {
+      "delete": {
+        "description": "User can get all managers",
+        "summary": "allows a user to retrieve all managers",
+        "tags": [""],
+        "produces": ["application/json"],
+        "security": [],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "description": "This is the request body object containing user request status",
             "schema": {
               "$ref": "#"
             }
@@ -644,6 +672,26 @@
             "updatedAt": "2019-09-05T18:39:51.988Z"
           }
         ]
+      }
+    },  
+    "delete_comment": {
+      "title": "User delete Comment",
+      "type": "object",
+      "properties": {
+        "status": {
+          "description": "Status of the user's request application",
+          "type": "string"
+        },
+        "comment_id": {
+          "description": "ID of the comment to be deleted",
+          "type": "integer"
+        }
+      },
+      "example": {
+        "status": "success",
+        "data": {
+          "message": "comment deleted successfully"                
+        }
       }
     }
   }


### PR DESCRIPTION
### What does this PR do?
- Creates an endpoint that enables users to get all managers

### Description of tasks to be completed
- Create a method named `getManagers`  that returns all managers in the user.controller,js file
- Modified ...users.seeder.js file to include more records of users whose roles are managers
- Create getmanagers.test.js file with contains the tests
- Document the endpoint using swagger

### How should this be manually tested?
-  Clone this repository to you local machine
-  Run `npm install` to install node packages
-  Run `npm run undo:migration`
-  Run `npm run db:migrate`
-  Run `npm run db:seed`
-  On any endpoint testing tool make a request to `http://localhost:3000/api/v1/managers` to retrieve all available managers
- Run `npm test` to test endpoint

### What are the relevant Pivotal Tacker stories?
#168267722 

### Any background context you want to provide?
- only logged in users are permitted to access the endpoint

### Screenshots (if appropriate)
![Screenshot (472)](https://user-images.githubusercontent.com/33726993/64311141-3c4fea80-cfa3-11e9-9f25-176092320a39.png)
