### PR TITLE
#168250754 Fetch Single Travel Request

### DIFF
--- a/src/db/seeders/20190828065701-users-seeder.js
+++ b/src/db/seeders/20190828065701-users-seeder.js
@@ -3,6 +3,34 @@ const bcrypt = require('bcrypt');
 module.exports = {
   up: async (queryInterface) => queryInterface.bulkInsert('users', [
     {
+      first_name: 'Bola',
+      last_name: 'Akinjide',
+      email: 'bola.akin@email.com',
+      password: await bcrypt.hash('bolaji99', 10),
+      gender: 'male',
+      birth_date: new Date('1995-11-22'),
+      preferred_language: 'en',
+      preferred_currency: 'NGN',
+      location: 'Nigeria',
+      role: 'manager',
+      created_at: new Date(),
+      updated_at: new Date()
+    },
+    {
+      first_name: 'Helen',
+      last_name: 'McMillan',
+      email: 'h.milan@email.com',
+      password: await bcrypt.hash('milanogelato', 10),
+      gender: 'female',
+      birth_date: new Date('1989-08-11'),
+      preferred_language: 'en',
+      preferred_currency: 'USD',
+      location: 'USA',
+      role: 'manager',
+      created_at: new Date(),
+      updated_at: new Date()
+    },
+    {
       first_name: 'John',
       last_name: 'Doe',
       email: 'john_doe@email.com',
@@ -13,6 +41,7 @@ module.exports = {
       preferred_currency: 'USD',
       location: 'Texas',
       role: 'requester',
+      manager_id: 1,
       created_at: new Date(),
       updated_at: new Date()
     },
@@ -27,6 +56,7 @@ module.exports = {
       preferred_currency: 'GBP',
       location: 'Texas',
       role: 'travel_admin',
+      manager_id: 1,
       created_at: new Date(),
       updated_at: new Date()
     },
@@ -69,6 +99,7 @@ module.exports = {
       preferred_currency: 'YEN',
       location: 'Jupiter',
       role: 'super_admin',
+      manager_id: 2,
       created_at: new Date(),
       updated_at: new Date()
     }

--- a/src/db/seeders/20190828065852-comments-seeder.js
+++ b/src/db/seeders/20190828065852-comments-seeder.js
@@ -2,7 +2,7 @@ module.exports = {
   up: async (queryInterface) => {
     await queryInterface.bulkInsert('requests', [
       {
-        user_id: 1,
+        user_id: 2,
         category: 'one-way',
         origin: 'Paris',
         destination: ['Lagos'],
@@ -14,7 +14,7 @@ module.exports = {
         updated_at: new Date()
       },
       {
-        user_id: 2,
+        user_id: 3,
         category: 'round-trip',
         origin: 'Hamburg',
         destination: ['Tokyo'],
@@ -26,7 +26,7 @@ module.exports = {
         updated_at: new Date()
       },
       {
-        user_id: 1,
+        user_id: 4,
         category: 'multi-city',
         origin: 'Munich',
         destination: ['Rome', 'Serbia & Montenegro', 'Madagascar'],

--- a/src/routes/api/requests.router.js
+++ b/src/routes/api/requests.router.js
@@ -18,6 +18,7 @@ router.patch('/requests/decline/:id',
 
 router.get('/requests', Auth.verifyToken, RequestController.findAll);
 router.post('/requests', Auth.verifyToken, Validator.Requests, RequestController.TripRequests);
+router.get('/requests/:request_id', Auth.verifyToken, RequestController.getSingleRequest);
 
 router.post('/request/multi-city', auth.verifyUserToken, RequestController.createMultiCityRequest);
 

--- a/src/test/request/get-single.test.js
+++ b/src/test/request/get-single.test.js
@@ -1,0 +1,186 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import sinon from 'sinon';
+
+import app from '../../index';
+import models from '../../db/models';
+import JWTService from '../../services/jwt.service';
+
+
+chai.use(chaiHttp);
+chai.should();
+
+const { expect } = chai;
+const { Request } = models;
+
+
+describe('GET /api/v1/requests/:request_id', () => {
+  const urlBase = '/api/v1/requests';
+
+  describe('SUCCESS', () => {
+      it('should fetch a request for the request owner', async () => {
+          const userDetails = { id: 3, role: 'requester' };
+          const requestId = 2;
+          const userToken = JWTService.generateToken(userDetails);
+
+          const res = await chai.request(app)
+              .get(`${urlBase}/${requestId}`)
+              .set('Authorization', `Bearer ${userToken}`)
+              .send();
+
+          expect(res.status).to.equal(200);
+          expect(res.body).to.have.keys('status', 'data');
+          expect(res.body.status).to.equal('success');
+          expect(res.body.data).to.be.an('object');
+          expect(res.body.data).to.have.keys('id', 'user_id', 'category', 'origin',
+              'destination', 'departure_date', 'return_date', 'reason', 'booking_id',
+              'createdAt', 'updatedAt', 'status', 'User', 'Booking');
+          expect(res.body.data.id).to.equal(requestId);
+          expect(res.body.data.user_id).to.equal(userDetails.id);
+          expect(res.body.data.User.id).to.equal(userDetails.id);
+          expect(res.body.data.booking_id).to.equal(res.body.data.Booking.id);
+      });
+
+      it('should fetch a request for request owner\'s manager', async () => {
+          const userDetails = { id: 1, role: 'manager' };
+          const requestId = 2;
+          const userToken = JWTService.generateToken(userDetails);
+
+          const res = await chai.request(app)
+              .get(`${urlBase}/${requestId}`)
+              .set('Authorization', `Bearer ${userToken}`)
+              .send();
+
+          expect(res.status).to.equal(200);
+          expect(res.body).to.have.keys('status', 'data');
+          expect(res.body.status).to.equal('success');
+          expect(res.body.data).to.be.an('object');
+          expect(res.body.data).to.have.keys('id', 'user_id', 'category', 'origin',
+              'destination', 'departure_date', 'return_date', 'reason', 'booking_id',
+              'createdAt', 'updatedAt', 'status', 'User', 'Booking');
+          expect(res.body.data.id).to.equal(requestId);
+          expect(res.body.data.User.manager_id).to.equal(userDetails.id);
+          expect(res.body.data.booking_id).to.equal(res.body.data.Booking.id);
+      });
+
+      it('should fetch a request for a super admin', async () => {
+          const userDetails = { id: 5, role: 'super_admin' };
+          const requestId = 2;
+          const userToken = JWTService.generateToken(userDetails);
+
+          const res = await chai.request(app)
+              .get(`${urlBase}/${requestId}`)
+              .set('Authorization', `Bearer ${userToken}`)
+              .send();
+
+          expect(res.status).to.equal(200);
+          expect(res.body).to.have.keys('status', 'data');
+          expect(res.body.status).to.equal('success');
+          expect(res.body.data).to.be.an('object');
+          expect(res.body.data).to.have.keys('id', 'user_id', 'category', 'origin',
+              'destination', 'departure_date', 'return_date', 'reason', 'booking_id',
+              'createdAt', 'updatedAt', 'status', 'User', 'Booking');
+          expect(res.body.data.id).to.equal(requestId);
+          expect(res.body.data.booking_id).to.equal(res.body.data.Booking.id);
+      });
+  });
+  
+  describe('FAILURE', () => {
+      const permissionError = 'You do not have permission to view this travel request';
+      
+      it('should not fetch request with no token supplied',
+          async () => {
+          const requestId = 2;
+          const res = await chai.request(app)
+              .get(`${urlBase}/${requestId}`)
+              .send();
+
+          expect(res.status).to.equal(403);
+          expect(res.body).to.have.keys('status', 'error');
+          expect(res.body.status).to.equal('error');
+          expect(res.body.error.message).to.equal('You must be logged in to proceed');
+      });
+
+      it('should not fetch request with invalid token supplied', async () => {
+          const requestId = 2;
+          const res = await chai.request(app)
+              .get(`${urlBase}/${requestId}`)
+              .set('Authorization', `Bearer ${new Array(15).fill('kfkfjd42g').join('')}`)
+              .send();
+
+          expect(res.status).to.equal(400);
+          expect(res.body).to.have.keys('status', 'error');
+          expect(res.body.status).to.equal('error');
+          expect(res.body.error.message).to.equal('Authentication failed!');
+      });
+
+      it('should not fetch request for a non-owner, non-manager, non-super admin user',
+          async () => {
+          const userDetails = { id: 4, role: 'requester'};
+          const requestId = 2;
+          const userToken = JWTService.generateToken(userDetails);
+
+          const res = await chai.request(app)
+              .get(`${urlBase}/${requestId}`)
+              .set('Authorization', `Bearer ${userToken}`)
+              .send();
+
+          expect(res.status).to.equal(403);
+          expect(res.body).to.have.keys('status', 'error');
+          expect(res.body.status).to.equal('error');
+          expect(res.body.error.message).to.equal(permissionError);
+      });
+
+      it('should not fetch request for a manager otherwise of owner\'s manager',
+          async () => {
+          const userDetails = { id: 2, role: 'manager'};
+          const requestId = 2;
+          const userToken = JWTService.generateToken(userDetails);
+
+          const res = await chai.request(app)
+              .get(`${urlBase}/${requestId}`)
+              .set('Authorization', `Bearer ${userToken}`)
+              .send();
+
+          expect(res.status).to.equal(403);
+          expect(res.body).to.have.keys('status', 'error');
+          expect(res.body.status).to.equal('error');
+          expect(res.body.error.message).to.equal(permissionError);
+      });
+
+      it('should not fetch non-existing travel request',
+          async () => {
+          const userDetails = { id: 4, role: 'requester'};
+          const requestId = 112;
+          const userToken = JWTService.generateToken(userDetails);
+
+          const res = await chai.request(app)
+              .get(`${urlBase}/${requestId}`)
+              .set('Authorization', `Bearer ${userToken}`)
+              .send();
+
+          expect(res.status).to.equal(404);
+          expect(res.body).to.have.keys('status', 'error');
+          expect(res.body.status).to.equal('error');
+          expect(res.body.error.message).to.equal('Travel request not found');
+      });
+
+      it('should fake a server error', async () => {
+          const userDetails = { id: 4, role: 'requester'};
+          const userToken = JWTService.generateToken(userDetails);
+          const stub = sinon.stub(Request, 'findOne').throws(new Error());
+
+          const res = await chai.request(app)
+              .get(`${urlBase}/2`)
+              .set('Authorization', `Bearer ${userToken}`)
+              .send();
+          // Restore default behaviour of stub
+          stub.restore();
+
+          expect(res.status).to.equal(500);
+          expect(res.body).to.have.keys('status', 'error');
+          expect(res.body.status).to.equal('error');
+          expect(res.body.error.message).to.equal('Internal server error');
+      });
+  })
+});

--- a/src/test/request/request.test.js
+++ b/src/test/request/request.test.js
@@ -3,9 +3,11 @@ import chaiHttp from 'chai-http';
 import sinon from 'sinon';
 import Sinonchai from 'sinon-chai';
 import bcrypt from 'bcrypt';
+
 import app from '../../index';
 import models from '../../db/models';
 import Response from '../../utils/response.utils';
+import JWTService from '../../services/jwt.service';
 
 import RequestController from '../../controllers/request.controller';
 
@@ -493,7 +495,6 @@ describe('/POST REQUESTS', () => {
                 res.body.data.should.have.property('return_date');
                 res.body.data.should.have.property('reason').eql('For the fun of it');
                 res.body.data.should.have.property('booking_id').eql(1);
-                res.body.data.should.have.property('user_id').eql(1);
                 done();
             });
     });
@@ -513,7 +514,6 @@ describe('/POST REQUESTS', () => {
                 res.body.data.should.have.property('return_date');
                 res.body.data.should.have.property('reason').eql('For the fun of it');
                 res.body.data.should.have.property('booking_id').eql(1);
-                res.body.data.should.have.property('user_id').eql(1);
                 done();
             });
     });

--- a/src/test/signin.test.js
+++ b/src/test/signin.test.js
@@ -1,21 +1,20 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
-import bcrypt from 'bcrypt';
 
-import models from '../db/models';
 import app from '../index';
+import JWTService from '../services/jwt.service';
 
 chai.use(chaiHttp);
 
 const { expect } = chai;
 const signinUrl = '/api/v1/auth/signin';
-const { User } = models;
 
-const testUser = {
+const testUserDetails = {
   first_name: 'John',
   last_name: 'Doe',
   email: 'john_doe@email.com',
-  password: 'qwertyuiop'
+  password: 'qwertyuiop',
+  token: JWTService.generateToken(this)
 };
 
 describe(`POST ${signinUrl}`, () => {
@@ -24,8 +23,8 @@ describe(`POST ${signinUrl}`, () => {
       const res = await chai.request(app)
         .post(signinUrl)
         .send({
-          email: testUser.email,
-          password: testUser.password
+          email: testUserDetails.email,
+          password: testUserDetails.password
         });
 
       expect(res.status).to.equal(200);
@@ -39,9 +38,9 @@ describe(`POST ${signinUrl}`, () => {
         'createdAt', 'gender', 'birth_date', 'preferred_language',
         'preferred_currency', 'location', 'token', 'email_notification');
       expect(res.body.data.token).to.be.a('string');
-      expect(res.body.data.first_name).to.equal(testUser.first_name);
-      expect(res.body.data.last_name).to.equal(testUser.last_name);
-      expect(res.body.data.email).to.equal(testUser.email);
+      expect(res.body.data.first_name).to.equal(testUserDetails.first_name);
+      expect(res.body.data.last_name).to.equal(testUserDetails.last_name);
+      expect(res.body.data.email).to.equal(testUserDetails.email);
     });
   });
 
@@ -49,7 +48,7 @@ describe(`POST ${signinUrl}`, () => {
     it('should fail to sign in user with incorrect email', async () => {
       const res = await chai.request(app)
         .post(signinUrl)
-        .send({ email: 'another@example.com', password: testUser.password });
+        .send({ email: 'another@example.com', password: testUserDetails.password });
 
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object');
@@ -64,7 +63,7 @@ describe(`POST ${signinUrl}`, () => {
     it('should fail to sign in user with no email field in request', async () => {
       const res = await chai.request(app)
         .post(signinUrl)
-        .send({ password: testUser.password });
+        .send({ password: testUserDetails.password });
 
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object');
@@ -79,7 +78,7 @@ describe(`POST ${signinUrl}`, () => {
     it('should fail to sign in user with empty email string', async () => {
       const res = await chai.request(app)
         .post(signinUrl)
-        .send({ email: '', password: testUser.password });
+        .send({ email: '', password: testUserDetails.password });
 
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object');
@@ -94,7 +93,7 @@ describe(`POST ${signinUrl}`, () => {
     it('should fail to sign in user with non-string email', async () => {
       const res = await chai.request(app)
         .post(signinUrl)
-        .send({ email: 10, password: testUser.password });
+        .send({ email: 10, password: testUserDetails.password });
 
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object');
@@ -109,7 +108,7 @@ describe(`POST ${signinUrl}`, () => {
     it('should fail to sign in user with invalid email format', async () => {
       const res = await chai.request(app)
         .post(signinUrl)
-        .send({ email: 'user@example', password: testUser.password });
+        .send({ email: 'user@example', password: testUserDetails.password });
 
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object');
@@ -124,7 +123,7 @@ describe(`POST ${signinUrl}`, () => {
     it('should fail to sign in user with incorrect password', async () => {
       const res = await chai.request(app)
         .post(signinUrl)
-        .send({ email: testUser.email, password: 'emi naa ni' });
+        .send({ email: testUserDetails.email, password: 'emi naa ni' });
 
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object');
@@ -139,7 +138,7 @@ describe(`POST ${signinUrl}`, () => {
     it('should fail to sign in user with no password field supplied', async () => {
       const res = await chai.request(app)
         .post(signinUrl)
-        .send({ email: testUser.email });
+        .send({ email: testUserDetails.email });
 
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object');
@@ -154,7 +153,7 @@ describe(`POST ${signinUrl}`, () => {
     it('should fail to sign in user with empty password string', async () => {
       const res = await chai.request(app)
         .post(signinUrl)
-        .send({ email: testUser.email, password: '' });
+        .send({ email: testUserDetails.email, password: '' });
 
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object');
@@ -169,7 +168,7 @@ describe(`POST ${signinUrl}`, () => {
     it('should fail to sign in user with non-string password', async () => {
       const res = await chai.request(app)
         .post(signinUrl)
-        .send({ email: testUser.email, password: 10 });
+        .send({ email: testUserDetails.email, password: 10 });
 
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object');
@@ -184,7 +183,7 @@ describe(`POST ${signinUrl}`, () => {
     it('should fail to sign in user with a too short password', async () => {
       const res = await chai.request(app)
         .post(signinUrl)
-        .send({ email: testUser, password: testUser.password.slice(0, 6) });
+        .send({ email: testUserDetails, password: testUserDetails.password.slice(0, 6) });
 
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object');

--- a/src/test/social-auth.test.js
+++ b/src/test/social-auth.test.js
@@ -1,5 +1,7 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
+import sgMail from '@sendgrid/mail';
+import sinon from 'sinon';
 
 import app from '../index';
 
@@ -12,6 +14,7 @@ const authBase = '/api/v1/auth';
 describe('SOCIAL AUTHENTICATION', () => {
   describe('SUCCESS', () => {
     it('should save a google user into the database', async () => {
+      const stub = sinon.stub(sgMail, 'send').callsFake((msg) => 'done');
       const res = await chai.request(app)
         .post(`${authBase}/google`)
         .send({ provider: 'google' });
@@ -33,6 +36,8 @@ describe('SOCIAL AUTHENTICATION', () => {
       expect(res.body.data.last_name).to.not.equal(null);
       expect(res.body.data.email).to.not.equal(null);
       expect(res.body.data.email).to.be.a('string');
+      expect(stub.called).to.equal(true);
+      stub.restore();
     });
 
     it('should save a facebook user into the database', async () => {

--- a/src/utils/response.utils.js
+++ b/src/utils/response.utils.js
@@ -60,4 +60,17 @@ export default class {
       }
     });
   }
+
+  /**
+   * Defines the specification for 404 server errors
+   * @param {ServerResponse} res
+   * @param {string} message
+   * @returns {ServerResponse} response
+   */
+  static NotFoundError(res, message) {
+    return res.status(404).json({
+      status: 'error',
+      error: { message }
+    });
+  }
 }

--- a/swagger.json
+++ b/swagger.json
@@ -10,10 +10,15 @@
   "host": "",
   "basePath": "/api/v1",
   "securityDefinitions": {
-    "Bearer": {
+    "x-access": {
       "description": "Standard Authorization header using the bearer scheme. Example: \"bearer {token}\"",
       "type": "apiKey",
       "name": "x-access-token",
+      "in": "header"
+    },
+    "Bearer": {
+      "type": "apiKey",
+      "name": "Authorization",
       "in": "header"
     }
   },
@@ -80,6 +85,7 @@
         "parameters": [
           {
             "in": "body",
+            "name": "body",
             "required": true,
             "description": "The request body for the signin endpoint",
             "schema": {
@@ -120,8 +126,7 @@
           }
         }
       }
-    }
-  },
+    },
     "/auth/passwordreset": {
       "get": {
         "tags": [
@@ -210,7 +215,6 @@
         }
       }
     },
-
     "/role": {
       "patch": {
         "description": "Update profile",
@@ -236,7 +240,6 @@
         }
       }
     },
-    
     "/requests/:id": {
       "patch": {
         "description": "A manager can reject a user's request application",
@@ -477,9 +480,52 @@
           }
         }
       }
-    
+    },
+    "/requests/{request_id}": {
+      "get": {
+        "tags": [
+          "Requests"
+        ],
+        "summary": "Fetch a single travel request",
+        "description": "This endpoint fetches a single travel request (with booking and user) using its ID. Only a request owner, his/her manager, or super admin can access a request",
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "path",
+            "description": "ID of the travel request to fetch",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Invalid token"
+          },
+          "403": {
+            "description": "No permission to view resource"
+          },
+          "404": {
+            "description": "Travel request not found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    }
   },
-
   "requestBody": {
     "signup": {
       "title": "Signup Request",
@@ -546,7 +592,6 @@
     },
     "signin": {
       "type": "object",
-      "title": "Signin request body specification",
       "required": ["email", "password"],
       "properties": {
         "email": {


### PR DESCRIPTION
#### What does this PR do?
Provides the implementation to fetch a single travel request by its ID

#### Description of Task to be completed?
- Have endpoint GET `/api/v1/requests/:request_id` working
- Document endpoint using Swagger

#### How should this be manually tested?
Clone this repo, cd into it and 
- Run `npm test`
- Or run `npm run start:dev`, then using an API test tool like Postman send GET requests to
  `/api/v1/requests/:request_id` on localhost
_key_: Port value: 3000
_key_: requires bearer token authentication

#### Any background context you want to provide?
A user should be able to view one of his/her requests, a manager should be able to view a single request of a user under his management, and a superadmin should be able to view any request

#### What are the relevant pivotal tracker stories?
[#168250754](https://www.pivotaltracker.com/story/show/168250754)

#### Screenshots (if appropriate)
None

#### Questions:
None