### PR TITLE
feature(booking): implement facility booking

### DIFF
--- a/src/db/migrations/20190821153031-create-booking.js
+++ b/src/db/migrations/20190821153031-create-booking.js
@@ -26,11 +26,12 @@ module.exports = {
         onDelete: 'CASCADE'
       },
       departure_date: {
-        type: Sequelize.DATE,
+        type: Sequelize.DATEONLY,
         allowNull: false
       },
       return_date: {
-        type: Sequelize.DATE,
+        type: Sequelize.DATEONLY,
+        allowNull: false
       },
       checked_in: {
         type: Sequelize.BOOLEAN,

--- a/src/db/models/booking.js
+++ b/src/db/models/booking.js
@@ -1,11 +1,12 @@
 module.exports = (sequelize, DataTypes) => {
   const Booking = sequelize.define('Booking', {
     departure_date: {
-      type: DataTypes.DATE,
+      type: DataTypes.DATEONLY,
       allowNull: false
     },
     return_date: {
-      type: DataTypes.DATE,
+      type: DataTypes.DATEONLY,
+      allowNull: false
     },
     checked_in: {
       type: DataTypes.BOOLEAN,

--- a/src/db/seeders/20190828065846-bookings-seeder.js
+++ b/src/db/seeders/20190828065846-bookings-seeder.js
@@ -3,14 +3,15 @@ module.exports = {
     user_id: 1,
     room_id: 1,
     departure_date: new Date(),
+    return_date: new Date(new Date().getTime() + 14 * 24 * 3600000),
     created_at: new Date(),
     updated_at: new Date()
   },
   {
     user_id: 2,
     room_id: 2,
-    departure_date: new Date(),
-    return_date: new Date(),
+    departure_date: new Date(new Date().getTime() + 7 * 24 * 3600000),
+    return_date: new Date(new Date().getTime() + 24 * 24 * 3600000),
     created_at: new Date(),
     updated_at: new Date()
   }], {}),

--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -1,5 +1,6 @@
 import jwt from 'jsonwebtoken';
 import models from '../db/models';
+import Response from '../utils/response.utils';
 
 const { User } = models;
 
@@ -40,6 +41,7 @@ const auth = {
       }
 
       const user = await User.findOne({ where: { id: decoded.payload.id } });
+      if (!user) return Response.UnauthorizedError(res, 'Failed to authenticate token', 401);
       req.currentUser = user;
       const { payload } = decoded;
       req.body.user = user;

--- a/src/middlewares/facilities.middleware.js
+++ b/src/middlewares/facilities.middleware.js
@@ -1,7 +1,10 @@
 import FacilityUtils from '../utils/facility.utils';
+import Response from '../utils/response.utils';
+import HelperUtils from '../utils/helpers.utils';
 
 const { getFacilitiesDetails } = FacilityUtils;
 const { getRoomsDetails } = FacilityUtils;
+const dateIntervalError = 'The return date must be ahead of the departure date';
 
 const FacilitiesChecks = {
   async getFacilitiesValues(req, res, next) {
@@ -39,6 +42,33 @@ const FacilitiesChecks = {
       status: 'error',
       error: 'You have not entered any room details'
     });
+  },
+
+  /**
+   * Ensures the date fields supplied in the booking request are valid
+   * @param {object} req
+   * @param {object} res
+   * @param {object} next
+   * @returns {undefined|object} nothing or ServerResponse object
+   */
+  validateBookingDates(req, res, next) {
+    const errors = {};
+    const { departure_date, return_date } = req.body;
+    // If any invalid date value exists populate an error on "errors"
+    HelperUtils.validateDatesFieldFormat({ departure_date, return_date }, errors);
+    // If departure date is same as or ahead of return date populate an error on "errors"
+    if ((new Date(return_date) - new Date(departure_date)) <= 0) {
+      errors.intervalError = dateIntervalError;
+    }
+    // If departure date is lesser than today populate an error on "errors"
+    const today = new Date().toISOString().split('T')[0];
+    if ((new Date(departure_date) - new Date(today)) < 0) {
+      errors.departureDateError = 'Departure date cannot be lesser than today';
+    }
+    // If any error has occured return a bad request error, else proceed to the controller
+    if (Object.keys(errors).length) return Response.BadRequestError(res, errors);
+
+    next();
   }
 };
 

--- a/src/routes/api/facilities.router.js
+++ b/src/routes/api/facilities.router.js
@@ -5,6 +5,7 @@ import validateFacilities from '../../validation/facilities/facilities.validatio
 import validateRooms from '../../validation/facilities/rooms.validation';
 import FacilitiesChecks from '../../middlewares/facilities.middleware';
 
+
 const router = express.Router();
 
 /* Requests Routes Here */
@@ -28,5 +29,8 @@ router.post('/facilities/rooms',
 
 router.get('/facilities',
   facilitiesController.getAllFacilities);
+
+router.post('/facilities/rooms/:room_id/book', auth.verifyUserToken,
+  FacilitiesChecks.validateBookingDates, facilitiesController.bookFacility);
 
 export default router;

--- a/src/test/facilities/booking.test.js
+++ b/src/test/facilities/booking.test.js
@@ -1,0 +1,458 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import sinon from 'sinon';
+
+import JWTService from '../../services/jwt.service';
+import app from '../../index';
+import models from '../../db/models';
+
+chai.use(chaiHttp);
+
+
+const { expect } = chai;
+const { Booking } = models;
+const userToken = JWTService.generateToken({ id: 3, role: 'reqeuster' });
+const baseUrl = '/api/v1/facilities/rooms';
+
+
+describe(`POST ${baseUrl}/:room_id/book`, () => {
+  describe('SUCCESS', () => {
+    it('should book an accomodation for a time not yet booked', async () => {
+      const roomId = 2;
+      const testBookingData = {
+        // Coming in one month time
+        departure_date: new Date(new Date().getTime() + 30 * 24 * 3600000)
+          .toISOString().split('T')[0],
+        // To spend 3 months
+        return_date: new Date(new Date().getTime() + 120 * 24 * 3600000)
+          .toISOString().split('T')[0]
+      };
+
+      const res = await chai.request(app)
+        .post(`${baseUrl}/${roomId}/book`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .send(testBookingData);
+
+      expect(res.status).to.equal(201);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.be.an('object');
+      expect(res.body.data).to.have.keys('id', 'user_id', 'room_id',
+        'departure_date', 'return_date', 'checked_in', 'createdAt', 'updatedAt');
+      expect(res.body.data.user_id).to.equal(3);
+      expect(res.body.data.room_id).to.be.equal(roomId);
+      expect(res.body.data.departure_date).to.equal(new Date(
+        testBookingData.departure_date).toISOString().split('T')[0])
+      expect(res.body.data.return_date).to.equal(new Date(
+          testBookingData.return_date).toISOString().split('T')[0])
+    });
+
+    it('should book same accomodation for a different time and interval', async () => {
+      const roomId = 2;
+      const testBookingData = {
+        // Coming in 5 month time
+        departure_date: new Date(new Date().getTime() + 150 * 24 * 3600000)
+          .toISOString().split('T')[0],
+        // To spend a week
+        return_date: new Date(new Date().getTime() + 157 * 24 * 3600000)
+          .toISOString().split('T')[0]
+      };
+
+      const res = await chai.request(app)
+        .post(`${baseUrl}/${roomId}/book`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .send(testBookingData);
+
+      expect(res.status).to.equal(201);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.be.an('object');
+      expect(res.body.data).to.have.keys('id', 'user_id', 'room_id',
+        'departure_date', 'return_date', 'checked_in', 'createdAt', 'updatedAt');
+      expect(res.body.data.user_id).to.equal(3);
+      expect(res.body.data.room_id).to.be.equal(roomId);
+      expect(res.body.data.departure_date).to.equal(new Date(
+        testBookingData.departure_date).toISOString().split('T')[0])
+      expect(res.body.data.return_date).to.equal(new Date(
+          testBookingData.return_date).toISOString().split('T')[0])
+    });
+  });
+
+
+  describe('FAILURE', () => {
+    it('should fail to book an accomodation when token not provided', async () => {
+      const roomId = 2;
+      const res = await chai.request(app)
+        .post(`${baseUrl}/${roomId}/book`)
+        .send({
+          // Coming in 6 month time
+          departure_date: new Date(new Date().getTime() + 180 * 24 * 3600000)
+            .toISOString().split('T')[0],
+          // To spend a week
+          return_date: new Date(new Date().getTime() + 187 * 24 * 3600000)
+            .toISOString().split('T')[0]
+        });
+      
+      expect(res.status).to.equal(401);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.equal('No token provided!');
+    });
+
+    it('should fail to book an accomodation when invalid token is provided',
+      async () => {
+        const roomId = 2;
+        const res = await chai.request(app)
+          .post(`${baseUrl}/${roomId}/book`)
+          .set('Authorization', `Bearer ${new Array(10).fill('pkdlfm').join('')}`)
+          .send({
+            // Coming in 6 month time
+            departure_date: new Date(new Date().getTime() + 180 * 24 * 3600000)
+              .toISOString().split('T')[0],
+            // To spend a week
+            return_date: new Date(new Date().getTime() + 187 * 24 * 3600000)
+              .toISOString().split('T')[0]
+          });
+        
+        expect(res.status).to.equal(401);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.keys('status', 'error');
+        expect(res.body.status).to.equal('error');
+        expect(res.body.error).to.equal('Invalid authentication token.');
+      });
+
+    it('should fail to book an accomodation with a valid token for which user exist not in the db',
+      async () => {
+        const nonExistingUserToken = JWTService.generateToken({ id: 1000, role: 'requester' });
+        const roomId = 2;
+        const res = await chai.request(app)
+          .post(`${baseUrl}/${roomId}/book`)
+          .set('Authorization', `Bearer ${nonExistingUserToken}`)
+          .send({
+            // Coming in 6 month time
+            departure_date: new Date(new Date().getTime() + 180 * 24 * 3600000)
+              .toISOString().split('T')[0],
+            // To spend a week
+            return_date: new Date(new Date().getTime() + 187 * 24 * 3600000)
+              .toISOString().split('T')[0]
+          });
+        
+        expect(res.status).to.equal(401);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.keys('status', 'error');
+        expect(res.body.status).to.equal('error');
+        expect(res.body.error).to.equal('Failed to authenticate token');
+      });
+
+    it('should fail to book an accomodation with no departure date provided',
+      async () => {
+        const roomId = 2;
+        const res = await chai.request(app)
+          .post(`${baseUrl}/${roomId}/book`)
+          .set('Authorization', `Bearer ${userToken}`)
+          .send({
+            return_date: new Date(new Date().getTime() + 187 * 24 * 3600000)
+              .toISOString().split('T')[0]
+          });
+        
+        expect(res.status).to.equal(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.keys('status', 'error');
+        expect(res.body.status).to.equal('error');
+        expect(res.body.error).to.have.property('departure_date')
+        expect(res.body.error.departure_date).to.equal(
+          'Invalid date. Please ensure the date in the format YYYY-MM-DD');
+      });
+
+    it('should fail to book an accomodation with no return date provided',
+      async () => {
+        const roomId = 2;
+        const res = await chai.request(app)
+          .post(`${baseUrl}/${roomId}/book`)
+          .set('Authorization', `Bearer ${userToken}`)
+          .send({
+            // Coming in 6 month time
+            departure_date: new Date(new Date().getTime() + 180 * 24 * 3600000)
+              .toISOString().split('T')[0]
+          });
+        
+        expect(res.status).to.equal(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.keys('status', 'error');
+        expect(res.body.status).to.equal('error');
+        expect(res.body.error).to.have.property('return_date')
+        expect(res.body.error.return_date).to.equal(
+          'Invalid date. Please ensure the date in the format YYYY-MM-DD');
+      });
+
+    it('should fail to book an accomodation when invalid departure date is provided',
+      async () => {
+        const roomId = 2;
+        const res = await chai.request(app)
+          .post(`${baseUrl}/${roomId}/book`)
+          .set('Authorization', `Bearer ${userToken}`)
+          .send({
+            // Invalid departure date
+            departure_date: '2020-06-32',
+            return_date: new Date(new Date().getTime() + 187 * 24 * 3600000)
+              .toISOString().split('T')[0]
+          });
+        
+        expect(res.status).to.equal(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.keys('status', 'error');
+        expect(res.body.status).to.equal('error');
+        expect(res.body.error).to.have.property('departure_date')
+        expect(res.body.error.departure_date).to.equal(
+          'Invalid date. Please ensure the date in the format YYYY-MM-DD');
+      });
+
+    it('should fail to book an accomodation when invalid return date is provided',
+      async () => {
+        const roomId = 2;
+        const res = await chai.request(app)
+          .post(`${baseUrl}/${roomId}/book`)
+          .set('Authorization', `Bearer ${userToken}`)
+          .send({
+            // Coming in 6 month time
+            departure_date: new Date(new Date().getTime() + 180 * 24 * 3600000)
+              .toISOString().split('T')[0],
+            return_date: '2020-13-10'
+          });
+        
+        expect(res.status).to.equal(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.keys('status', 'error');
+        expect(res.body.status).to.equal('error');
+        expect(res.body.error).to.have.property('return_date')
+        expect(res.body.error.return_date).to.equal(
+          'Invalid date. Please ensure the date in the format YYYY-MM-DD');
+      });
+
+    it('should fail to book an accomodation when departure and return dates are same',
+      async () => {
+        const roomId = 2;
+        const res = await chai.request(app)
+          .post(`${baseUrl}/${roomId}/book`)
+          .set('Authorization', `Bearer ${userToken}`)
+          .send({
+            // Coming in 6 month time
+            departure_date: new Date(new Date().getTime() + 180 * 24 * 3600000)
+              .toISOString().split('T')[0],
+            // Same day
+            return_date: new Date(new Date().getTime() + 180 * 24 * 3600000)
+            .toISOString().split('T')[0]
+          });
+        
+        expect(res.status).to.equal(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.keys('status', 'error');
+        expect(res.body.status).to.equal('error');
+        expect(res.body.error).to.have.property('intervalError')
+        expect(res.body.error.intervalError).to.equal(
+          'The return date must be ahead of the departure date');
+      });
+
+    it('should fail to book an accomodation when departure date is ahead of return date',
+      async () => {
+        const roomId = 2;
+        const res = await chai.request(app)
+          .post(`${baseUrl}/${roomId}/book`)
+          .set('Authorization', `Bearer ${userToken}`)
+          .send({
+            // Coming in 6 month time
+            departure_date: new Date(new Date().getTime() + 182 * 24 * 3600000)
+              .toISOString().split('T')[0],
+            // Two days before departure date
+            return_date: new Date(new Date().getTime() + 180 * 24 * 3600000)
+            .toISOString().split('T')[0]
+          });
+        
+        expect(res.status).to.equal(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.keys('status', 'error');
+        expect(res.body.status).to.equal('error');
+        expect(res.body.error).to.have.property('intervalError')
+        expect(res.body.error.intervalError).to.equal(
+          'The return date must be ahead of the departure date');
+      });
+
+    it('should fail to book an accomodation when departure date is less than today',
+      async () => {
+        const roomId = 2;
+        const res = await chai.request(app)
+          .post(`${baseUrl}/${roomId}/book`)
+          .set('Authorization', `Bearer ${userToken}`)
+          .send({
+            // 2 days ago
+            departure_date: new Date(new Date().getTime() - 2 * 24 * 3600000)
+              .toISOString().split('T')[0],
+            // Six months away
+            return_date: new Date(new Date().getTime() + 180 * 24 * 3600000)
+            .toISOString().split('T')[0]
+          });
+        
+        expect(res.status).to.equal(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.keys('status', 'error');
+        expect(res.body.status).to.equal('error');
+        expect(res.body.error).to.have.property('departureDateError')
+        expect(res.body.error.departureDateError).to.equal(
+          'Departure date cannot be lesser than today');
+      });
+
+    it('should fail to book an accomodation when referenced room does not exist',
+      async () => {
+        const res = await chai.request(app)
+          .post(`${baseUrl}/120/book`)
+          .set('Authorization', `Bearer ${userToken}`)
+          .send({
+            // Coming in 6 month time
+            departure_date: new Date(new Date().getTime() + 180 * 24 * 3600000)
+              .toISOString().split('T')[0],
+            // To spend a week
+            return_date: new Date(new Date().getTime() + 187 * 24 * 3600000)
+              .toISOString().split('T')[0]
+          });
+        
+        expect(res.status).to.equal(404);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.keys('status', 'error');
+        expect(res.body.status).to.equal('error');
+        expect(res.body.error).to.be.an('object');
+        expect(res.body.error).to.have.key('message');
+        expect(res.body.error.message).to.equal('Room not found');
+      });
+
+    it('should fail to book an accomodation when both departure and return dates sought for a '
+      + 'new booking fall within an existing booking\'s dates for same room',
+      async () => {
+        const roomId = 2;
+        const res = await chai.request(app)
+          .post(`${baseUrl}/${roomId}/book`)
+          .set('Authorization', `Bearer ${userToken}`)
+          .send({
+            // Coming in two months time, while an existing booking starts in a month time
+            departure_date: new Date(new Date().getTime() + 60 * 24 * 3600000)
+              .toISOString().split('T')[0],
+            // To spend 1 month, the existing booking ends in 4 months time
+            return_date: new Date(new Date().getTime() + 90 * 24 * 3600000)
+              .toISOString().split('T')[0]
+          });
+
+        expect(res.status).to.equal(409);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.keys('status', 'error');
+        expect(res.body.status).to.equal('error');
+        expect(res.body.error).to.be.an('object');
+        expect(res.body.error).to.have.keys('message');
+        expect(res.body.error.message.startsWith('This accomodation is already book from'))
+          .to.be.true;
+      });
+
+    it('should fail to book an accomodation when both departure and return dates for an '
+      + 'existing booking fall within the dates sought for a new booking for same room' ,
+        async () => {
+          const roomId = 2;
+          const res = await chai.request(app)
+            .post(`${baseUrl}/${roomId}/book`)
+            .set('Authorization', `Bearer ${userToken}`)
+            .send({
+              // An existing booking starts in one month time, this starts in two weeks
+              departure_date: new Date(new Date().getTime() + 14 * 24 * 3600000)
+                .toISOString().split('T')[0],
+              // The existing booking ends in 4 months time, this ends in 8 months
+              return_date: new Date(new Date().getTime() + 240 * 24 * 3600000)
+                .toISOString().split('T')[0]
+            });
+
+          expect(res.status).to.equal(409);
+          expect(res.body).to.be.an('object');
+          expect(res.body).to.have.keys('status', 'error');
+          expect(res.body.status).to.equal('error');
+          expect(res.body.error).to.be.an('object');
+          expect(res.body.error).to.have.keys('message');
+          expect(res.body.error.message.startsWith('This accomodation is already book from'))
+            .to.be.true;
+        });
+
+    it('should fail to book an accomodation when only the departure date sought for a new '
+      + 'booking falls within an existing booking\'s dates for same room',
+      async () => {
+        const roomId = 2;
+        const res = await chai.request(app)
+          .post(`${baseUrl}/${roomId}/book`)
+          .set('Authorization', `Bearer ${userToken}`)
+          .send({
+            // Coming in two months time, while an existing booking starts in a month time
+            departure_date: new Date(new Date().getTime() + 60 * 24 * 3600000)
+              .toISOString().split('T')[0],
+            // Ends in 6 months, the existing booking ends in 4 months time
+            return_date: new Date(new Date().getTime() + 180 * 24 * 3600000)
+              .toISOString().split('T')[0]
+          });
+
+        expect(res.status).to.equal(409);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.keys('status', 'error');
+        expect(res.body.status).to.equal('error');
+        expect(res.body.error).to.be.an('object');
+        expect(res.body.error).to.have.keys('message');
+        expect(res.body.error.message.startsWith('This accomodation is already book from'))
+          .to.be.true;
+      });
+
+    it('should fail to book an accomodation when only the return date sought for a new '
+      + 'booking falls within an existing booking\'s dates for same room',
+        async () => {
+          const roomId = 2;
+          const res = await chai.request(app)
+            .post(`${baseUrl}/${roomId}/book`)
+            .set('Authorization', `Bearer ${userToken}`)
+            .send({
+              // Coming in two weeks time, while an existing booking starts in a month time
+              departure_date: new Date(new Date().getTime() + 14 * 24 * 3600000)
+                .toISOString().split('T')[0],
+              // To spend 2 months, the existing booking ends in 4 months time
+              return_date: new Date(new Date().getTime() + 74 * 24 * 3600000)
+                .toISOString().split('T')[0]
+            });
+
+          expect(res.status).to.equal(409);
+          expect(res.body).to.be.an('object');
+          expect(res.body).to.have.keys('status', 'error');
+          expect(res.body.status).to.equal('error');
+          expect(res.body.error).to.be.an('object');
+          expect(res.body.error).to.have.keys('message');
+          expect(res.body.error.message.startsWith('This accomodation is already book from'))
+            .to.be.true;
+        });
+
+    it('should test for internal server error', async () => {
+      const stub = sinon.stub(Booking, 'create').throws(new Error());
+      const roomId = 2;
+      const res = await chai.request(app)
+        .post(`${baseUrl}/${roomId}/book`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .send({
+          // Coming in 6 month time
+          departure_date: new Date(new Date().getTime() + 180 * 24 * 3600000)
+            .toISOString().split('T')[0],
+          // To spend a week
+          return_date: new Date(new Date().getTime() + 187 * 24 * 3600000)
+            .toISOString().split('T')[0]
+        });
+      
+      expect(res.status).to.equal(500);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.have.key('message');
+      expect(res.body.error.message).to.equal('Internal server error');
+      stub.restore();
+    });
+  });  
+})

--- a/src/test/social-auth.test.js
+++ b/src/test/social-auth.test.js
@@ -14,7 +14,8 @@ const authBase = '/api/v1/auth';
 describe('SOCIAL AUTHENTICATION', () => {
   describe('SUCCESS', () => {
     it('should save a google user into the database', async () => {
-      const stub = sinon.stub(sgMail, 'send').callsFake((msg) => 'done');
+      // The catch block for the email service file isn't running yet, make it
+      const stub = sinon.stub(sgMail, 'send').throws(new Error());
       const res = await chai.request(app)
         .post(`${authBase}/google`)
         .send({ provider: 'google' });

--- a/src/utils/facility.utils.js
+++ b/src/utils/facility.utils.js
@@ -1,3 +1,7 @@
+import sequelize from 'sequelize';
+
+const { Op } = sequelize;
+
 /**
  * Defines helper functions for the facility model
  */
@@ -50,5 +54,29 @@ export default class FacilityUtils {
       if (reqBody[key]) valuesToPost[key] = reqBody[key];
     });
     return valuesToPost;
+  }
+
+  /**
+   * Builds the query object that fetches an existing booking for an
+   * accomodation that conflicts with the present booking being sought
+   * @param {number} room_id
+   * @param {string} departure_date
+   * @param {string} return_date
+   * @returns {object} formatted query object
+   */
+  static getConflictingBookingQuery(room_id, departure_date, return_date) {
+    return {
+      // The goal is to build a query that checks if dates and intervals of a new
+      // booking about to be made conflicts with an existing booking's for same room
+      where: {
+        room_id,
+        [Op.and]: {
+          [Op.or]: [sequelize.literal(`'${departure_date}' between departure_date and return_date`),
+            sequelize.literal(`'${return_date}' between departure_date and return_date`),
+            sequelize.literal(`departure_date between '${departure_date}' and '${return_date}'`),
+            sequelize.literal(`return_date between '${departure_date}' and '${return_date}'`)],
+        }
+      }
+    };
   }
 }

--- a/src/utils/helpers.utils.js
+++ b/src/utils/helpers.utils.js
@@ -1,3 +1,5 @@
+const invalidDateError = 'Invalid date. Please ensure the date in the format YYYY-MM-DD';
+
 export default {
   checkForEmptyFields: (field, value) => {
     if (!value) return [`${field} is required`];
@@ -35,5 +37,20 @@ export default {
     }
 
     return values;
+  },
+
+  /**
+  * Validates the format
+  * @param {object} fields
+  * @param {object} errors
+  * @param {string} errorMessage
+  * @returns {undefined}
+  */
+  validateDatesFieldFormat(fields, errors, errorMessage = invalidDateError) {
+    // eslint-disable-next-line no-useless-escape
+    const dateRegex = /^[1-9]\d{3}\-(?:0[1-9]|1[0-2])\-(?:0[1-9]|[12][0-9]|3[01])$/;
+    Object.entries(fields).forEach(([key, value]) => {
+      if (!dateRegex.test(value)) errors[key] = errorMessage;
+    });
   }
 };

--- a/src/utils/response.utils.js
+++ b/src/utils/response.utils.js
@@ -87,4 +87,17 @@ export default class {
       error: { message }
     });
   }
+
+  /**
+   * Defines the specification for conflicting resource
+   * @param {object} res (ServerResponse)
+   * @param {object} error
+   * @returns {object} ServerResponse
+   */
+  static ConflictError(res, error) {
+    return res.status(409).json({
+      status: 'error',
+      error
+    });
+  }
 }

--- a/swagger.json
+++ b/swagger.json
@@ -714,6 +714,59 @@
           }
         }
       }
+    },
+    "/facilities/rooms/{room_id}/book": {
+      "post": {
+        "tags": ["Facilities"],
+        "summary": "Book an accomodation facility",
+        "description": "This endpoint receives POST requests to book a room in a facility.",
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "room_id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the room to be booked",
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "description": "The request body consisting of a \"departure_date\" field and a \"return_date\" field.",
+            "schema": {
+              "$ref":"#/requestBody/bookRoom"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Bad request. Invalid date fields, or date fields (or combination) not logical"
+          },
+          "401": {
+            "description": "Unauthorized request"
+          },
+          "404": {
+            "description": "Referenced room not found"
+          },
+          "409": {
+            "description": "Booking dates conflict with an existing booking for same room"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
     }
   },
   "requestBody": {
@@ -1114,6 +1167,27 @@
         "data": {
           "message": "comment deleted successfully"
         }
+      }
+    },
+    "bookRoom": {
+      "title": "Book an accomodation",
+      "type": "object",
+      "required": ["departure_date", "return_date"],
+      "properties": {
+        "departure_date": {
+          "description": "The date from which the booking will be effective",
+          "type": "string",
+          "format": "date"
+        },
+        "return_date": {
+          "description": "The date at which the booking will cease to be effective",
+          "type": "string",
+          "format": "date"
+        }
+      },
+      "example": {
+        "departure_date": "2019-10-22",
+        "return_date": "2020-02-19"
       }
     }
   }


### PR DESCRIPTION
#### What does this PR do?
Provides the implementation that allows a user to be able to book (a room in) an accomodation facility

#### Description of Task to be completed?
- Build out the endpoint `POST /api/v1/facilities/rooms/:room_id/book`
- Design an algorithm that ensures a user cannot book a room within a range of time it has already been booked for

#### How should this be manually tested?
Clone this repo, cd into it and 
- Run `npm test`
- Or run `npm run start:dev`, then 
  - Using an API testing tool (like Postman) send POST requests to `/api/v1/facilities/rooms/:room_id/book` on localhost
  - Or open `localhost:3000/api-docs`, find the documentation for this particular endpoint on the Swagger UI and send requests from there.

_key_: Port value: 3000
_key_: Content-Type value: application/json
_key_: Request body: `{ departure_date: YYYY-MM-DD, return_date: YYYY-MM-DD }`
_key_: Requires token authentication

#### Any background context you want to provide?
Users should be able to book accomodation facilities with dates they intend to spend in the premises and be assured of accomodation when they arrive

#### What are the relevant pivotal tracker stories?
[#167727482](https://www.pivotaltracker.com/story/show/167727482)

#### Screenshots (if appropriate)
None

#### Questions:
None