### PR TITLE
#167727476 Send notification when comment is added to a request

### DIFF
--- a/src/controllers/comment.controller.js
+++ b/src/controllers/comment.controller.js
@@ -22,11 +22,9 @@ export default class CommentController {
         comment,
         user_id: user.id
       });
-
-      res.status(201).json({
-        status: 'success',
-        data: postedComment
-      });
+      // sends the comment data to the notification middleware
+      req.body.commentData = postedComment;
+      return next(); // calls the notification middleware
     } catch (error) { next(error); }
   }
 

--- a/src/controllers/request.controller.js
+++ b/src/controllers/request.controller.js
@@ -219,12 +219,12 @@ export default class RequestController {
     }
   }
 
-   /**
+  /**
     * @param {object} req
     * @param {object} res
     * @returns {json} request
     */
-   static async approveRequest(req, res) {
+  static async approveRequest(req, res) {
     try {
       const request = await Request.update(
         {

--- a/src/middlewares/comment.middleware.js
+++ b/src/middlewares/comment.middleware.js
@@ -72,6 +72,9 @@ export default class AuthenticationMiddleware {
       const isPermitted = (user.id === request.user_id)
                             || (user.id === request.User.manager_id);
 
+      // make request available to the next middleware
+      req.body.requestData = request;
+
       return isPermitted
         ? next()
         : res.status(403).json({

--- a/src/middlewares/notification.middleware.js
+++ b/src/middlewares/notification.middleware.js
@@ -1,0 +1,50 @@
+import model from '../db/models/index';
+
+const { Notification } = model;
+
+/**
+ * Notifications middleware
+ */
+export default class NotificationMiddleware {
+  /**
+     * sends notification to user when a comment is made on a request
+     * @param {Object} req
+     * @param {Object} res
+     * @returns {JSON} responseBody
+     */
+  static async postCommentNotification(req, res) {
+    // requestData and commentData were gotten from the ensureUserCanPost and postComment middlewares respectively
+    const { requestData, user, commentData } = req.body;
+
+    try {
+      // send notification to User's manager if user owns the request
+      const responseMessage = (user.id === requestData.user_id)
+        ? 'A notification was sent to your manager.'
+        : 'A notification was sent to the request\'s owner.';
+
+      const receiver_id = (user.id === requestData.user_id)
+        ? requestData.User.manager_id
+        : requestData.user_id;
+
+      await Notification.create({
+        request_id: requestData.id,
+        subject: 'New Comment On Request',
+        notification: commentData.comment,
+        receiver_id
+      });
+
+      await res.status(201).json({
+        status: 'success',
+        data: commentData,
+        message: responseMessage
+      });
+    } catch (error) {
+      // sending a 201 status because although notification failed, comment was successfully posted
+      res.status(201).json({
+        status: 'success',
+        data: commentData,
+        message: 'Could not send notification.'
+      });
+    }
+  }
+}

--- a/src/routes/api/comment.router.js
+++ b/src/routes/api/comment.router.js
@@ -1,13 +1,16 @@
 import express from 'express';
 import CommentController from '../../controllers/comment.controller';
-import auth from "../../middlewares/auth";
+import auth from '../../middlewares/auth';
 import Authorization from '../../middlewares/comment.middleware';
 import validateComment from '../../validation/comment.validation';
+import NotificationMiddleware from '../../middlewares/notification.middleware';
+
+const { postCommentNotification } = NotificationMiddleware;
 
 const router = express.Router();
 
 /* comment Routes Here */
-router.post('/comments', auth.verifyUserToken, validateComment, Authorization.ensureUserCanPost, CommentController.postComment);
+router.post('/comments', auth.verifyUserToken, validateComment, Authorization.ensureUserCanPost, CommentController.postComment, postCommentNotification);
 router.delete('/comment/:comment_id', auth.verifyUserToken, Authorization.verifyCommentOwner, CommentController.deleteComment);
 router.get('/comment/:request_id', auth.verifyUserToken, Authorization.verifyPermission, CommentController.getComments);
 

--- a/src/test/bookings/checkin.test.js
+++ b/src/test/bookings/checkin.test.js
@@ -1,6 +1,10 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
+import sinon from 'sinon';
 import app from '../../index';
+import models from '../../db/models/index';
+
+const { Booking } = models;
 
 const { expect } = chai;
 chai.use(chaiHttp);
@@ -82,6 +86,18 @@ describe('Bookings', () => {
                 expect(res.body.status).to.deep.equal('success');
                 expect(res.body.data).to.have.keys('id', 'user_id', 'room_id', 'departure_date', 'return_date', 'checked_in', 'createdAt', 'updatedAt');
                 expect(res.body.data.checked_in).to.be.true;
+                done();
+            });
+        });
+
+        it('Should fake server error', (done) => {
+            const stub = sinon.stub(Booking, 'update').throws(new Error());
+            chai.request(app)
+            .patch('/api/v1/bookings/1/checkin')
+            .set('Authorization', myToken)
+            .end((error, res) => {
+                stub.restore();
+                expect(res).to.have.status(500);
                 done();
             });
         });


### PR DESCRIPTION
### What does this PR do?
- Sends a notification to either the owner of the request or his/her manager (depending on who adds the comment) when a new comment is added to the trip request

### Description of Task to be completed?
- Add tests for feature
- Write middleware logic that sends a notification to the right user

### How should this be manually tested?
##### Using Postman:
-  If you haven't already, download [Postman](https://www.getpostman.com/)
- Download or clone this repository
- Run `git branch -r` to get all the branches from github
- Run `git checkout -b ft-comment-notification-167727476 origin/ft-comment-notification-167727476 ` to have a copy of this branch.
- Check the `.env.example` file to know how to set your environment variables
- Run `npm run start:dev` The application should be running on `port 3000`
- Ensure you sign in via `localhost:3000/api/v1/auth/signin` using the following credentials:

```
{
      email: 'john_doe@email.com',
      password: 'qwertyuiop'
}
```
- Set the `Authorization` header to the token that was returned during authentication.
- Checkout the API documentation at `localhost:3000/api-docs` to find out how to structure your requests
- Send a `POST` request to `localhost:3000/api/v1/comments`

##### Testing locally.
- After cloning and checking out this branch (as listed in the steps above), run `npm test`

### What are the relevant Pivotal Tacker stories?
[#167727476](https://www.pivotaltracker.com/story/show/167727476 )